### PR TITLE
modified: main.cpp

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -18,7 +18,8 @@
 #include <openssl/bn.h>
 
 // 🧠 REAL-TIME INTELLIGENT FILTERING WITH CORNER DETECTION 🧠
-constexpr int N_THREADS = 16;
+// constexpr int N_THREADS = 16;
+int N_THREADS = std::thread::hardware_concurrency();
 constexpr int ANALYSIS_WINDOW = 10000;
 
 std::atomic<bool> FOUND(false);


### PR DESCRIPTION
removed: constexpr int N_THREADS = 16;
add: int N_THREADS = std::thread::hardware_concurrency();
- Can automaticaly use all available cpu threads in hardware